### PR TITLE
Fix build with Qt 6.4

### DIFF
--- a/adaptors/alsadaptor/alsadaptor.cpp
+++ b/adaptors/alsadaptor/alsadaptor.cpp
@@ -200,7 +200,7 @@ void ALSAdaptor::processSample(int pathId, int fd)
             sensordLogW() << "read(): " << strerror(errno);
             return;
         }
-        QVariant value(buffer);
+        QVariant value {QString(buffer)};
         bool ok;
         double fValue(value.toDouble(&ok));
         if(!ok) {

--- a/examples/filterplugin/samplefilter.h
+++ b/examples/filterplugin/samplefilter.h
@@ -32,6 +32,7 @@
 
 // Include datatypes for input and output.
 #include "timedunsigned.h"
+#include <QObject>
 
 // This is a simplest possible filter, with one input and one output.
 // In case you wish to create more complex filters, with several inputs


### PR DESCRIPTION
* fix: git/adaptors/alsadaptor/alsadaptor.cpp:203:30: error: use of deleted function 'QVariant::QVariant(T) [with T = char*; typename std::enable_if<disjunction_v<std::is_pointer<_Tp>, std::is_member_pointer<_Tp> >, bool>::type <anonymo us> = false]'

and

../../../git/examples/filterplugin/samplefilter.h:43:45: error: invalid use of incomplete type 'class QObject' ../../../git/examples/filterplugin/samplefilter.h:43:45: error: invalid use of incomplete type 'class QObject' moc_samplefilter.cpp:60:43: error: incomplete type 'QObject' used in nested name specifier moc_samplefilter.cpp:60:60: error: no matching function for call to 'QMetaObject::SuperData::link<<expression error> >()' moc_samplefilter.cpp:60:60: error: template argument 1 is invalid moc_samplefilter.cpp:82:21: error: incomplete type 'QObject' used in nested name specifier moc_samplefilter.cpp:82:50: error: incomplete type 'QObject' used in nested name specifier moc_samplefilter.cpp:92:21: error: incomplete type 'QObject' used in nested name specifier moc_samplefilter.cpp:97:20: error: incomplete type 'QObject' used in nested name specifier

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>